### PR TITLE
Jeff: Added timeout (default: 5 min) on request processing

### DIFF
--- a/src/server.mli
+++ b/src/server.mli
@@ -6,6 +6,7 @@ type socket_filename = string
 
 val handler_inet :
   ?read_timeout: float (* default: 60. seconds *) ->
+  ?processing_timeout: float (* default: 300. seconds *) ->
   ?write_timeout: float (* default: 60. seconds *) ->
   ?read_error_handler:(exn -> Response.t Lwt.t) ->
   ?write_error_handler:(exn -> unit Lwt.t) ->
@@ -17,6 +18,7 @@ val handler_inet :
 
 val handler_sock :
   ?read_timeout: float (* default: 60. seconds *) ->
+  ?processing_timeout: float (* default: 300. seconds *) ->
   ?write_timeout: float (* default: 60. seconds *) ->
   ?read_error_handler:(exn -> Response.t Lwt.t) ->
   ?write_error_handler:(exn -> unit Lwt.t) ->


### PR DESCRIPTION
This adds a timeout on the lwt thread that processes the request (after reading complete response, before writing response). The default is 300 seconds (5 min).
