### PR TITLE
Patch myocamlbuild.ml to not use internal ocamlbuild function.

### DIFF
--- a/samples/myocamlbuild.ml
+++ b/samples/myocamlbuild.ml
@@ -2,15 +2,24 @@ open Ocamlbuild_plugin
 
 (* ocamlfind integration following http://www.nabble.com/forum/ViewPost.jtp?post=15979274 *)
 
-(* these functions are not really officially exported *)
-let run_and_read = Ocamlbuild_pack.My_unix.run_and_read
-let blank_sep_strings = Ocamlbuild_pack.Lexers.blank_sep_strings
+let run_command cmd = 
+  let chan = Unix.open_process_in cmd in
+  let out =
+    let rec loop xs =
+      match input_line chan with
+      | x -> loop (x :: xs)
+      | exception End_of_file -> List.rev xs
+    in loop []
+  in
+  match Unix.close_process_in chan with
+  | Unix.WEXITED 0 -> `Ok out
+  | x -> `Error x
 
 (* this lists all supported packages *)
 let find_packages () =
-  blank_sep_strings &
-    Lexing.from_string &
-      run_and_read "ocamlfind list | cut -d' ' -f1"
+  match run_command "ocamlfind list | cut -d' ' -f1" with
+  | `Ok xs -> xs
+  | `Error _ -> failwith "Failed to find packages."
 
 (* this lists all supported packages *)
 let find_syntaxes () = ["camlp4o"]
@@ -33,7 +42,7 @@ dispatch begin function
 
       (* When one link an OCaml library/binary/package, one should use -linkpkg *)
        flag ["ocaml"; "compile"] (S[A"-dtypes"]);
-       flag ["ocaml"; "compile"] (S[A"-warn-error"; A"Ay"]);
+       flag ["ocaml"; "compile"] (S[A"-warn-error"; A"ay"]);
        flag ["ocaml"; "compile"] (S[A"-ppopt"; A"-lwt-debug"]);
 
        flag ["ocaml"; "link"] & A"-linkpkg";

--- a/samples/myocamlbuild.ml
+++ b/samples/myocamlbuild.ml
@@ -42,7 +42,7 @@ dispatch begin function
 
       (* When one link an OCaml library/binary/package, one should use -linkpkg *)
        flag ["ocaml"; "compile"] (S[A"-dtypes"]);
-       flag ["ocaml"; "compile"] (S[A"-warn-error"; A"ay"]);
+       flag ["ocaml"; "compile"] (S[A"-warn-error"; A"Ay"]);
        flag ["ocaml"; "compile"] (S[A"-ppopt"; A"-lwt-debug"]);
 
        flag ["ocaml"; "link"] & A"-linkpkg";

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,8 +23,9 @@ MLI = \
   client.mli
 
 CMAS = $(NAME).cma
+CMXS = $(NAME).cmx
 CMXAS = $(NAME).cmxa
-LIBS = $(CMAS) $(CMXAS)
+LIBS = $(CMAS) $(CMXS) $(CMXAS)
 BUILD = \
   $(addprefix _build/,$(LIBS)) \
   $(addprefix _build/,$(MLI)) \


### PR DESCRIPTION
I was running into the following error:

```
ocamlbuild -no-links -tag debug client_server_test.byte
+ /usr/local/bin/ocamlopt.opt unix.cmxa -I /usr/local/lib/ocaml/ocamlbuild /usr/local/lib/ocaml/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /usr/local/lib/ocaml/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
File "myocamlbuild.ml", line 12, characters 4-76:
Error: This expression has type Lexing.lexbuf
       but an expression was expected of type
         Ocamlbuild_pack.Loc.source = string
```

The interface of an internal ocamlbuild function that was used to
implement [find_packages] must have changed. I replaced it with a simple
reimplementation using the standard library.
